### PR TITLE
feat(knocks): サンプリングと曜日関係のDatetimeカラム

### DIFF
--- a/practice/100knocks-preprocess/docker/work/preprocess_knock_Python.ipynb
+++ b/practice/100knocks-preprocess/docker/work/preprocess_knock_Python.ipynb
@@ -11609,10 +11609,72 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 56,
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>customer_id</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>gender_cd</th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>298</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1793</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>107</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "           customer_id\n",
+       "gender_cd             \n",
+       "0                  298\n",
+       "1                 1793\n",
+       "9                  107"
+      ]
+     },
+     "execution_count": 56,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "_, df_tmp = train_test_split(df_customer, test_size=0.1, \n",
+    "                             stratify=df_customer['gender_cd'])\n",
+    "df_tmp.groupby('gender_cd').agg({'customer_id' : 'count'})"
+   ]
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## 概要
100本ノックの74から76問目までに取り組む


## 要件
* weekdayを利用して特定の週のはじめを求める
* sampleメソッドを使い表全体からサンプリングを行う
* scikit-learnを使って、特定のラベルごとの層化抽出を行う