### PR TITLE
feat(numpy100): 行列の特定の要素の座標を取得する

### DIFF
--- a/practice/numpy-100/100_Numpy_exercises.ipynb
+++ b/practice/numpy-100/100_Numpy_exercises.ipynb
@@ -710,10 +710,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(1, 5, 4)"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "np.unravel_index(100,(6,7,8))"
+   ]
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## 概要
numpy100問集の問20を解いてみる


## 要件
* unravel_indexで特定の要素の座標を取得することができる