### PR TITLE
feat(numpy100): 配列同士の比較と権限変更

### DIFF
--- a/practice/numpy-100/100_Numpy_exercises.ipynb
+++ b/practice/numpy-100/100_Numpy_exercises.ipynb
@@ -1403,10 +1403,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "False\n",
+      "False\n"
+     ]
+    }
+   ],
+   "source": [
+    "tmp = np.random.randint(0,2,5)\n",
+    "tmp2 = np.random.randint(0,2,5)\n",
+    "equal = np.allclose(tmp,tmp2)\n",
+    "print(equal)\n",
+    "\n",
+    "equal = np.array_equal(tmp,tmp2)\n",
+    "print(equal)"
+   ]
   },
   {
    "cell_type": "markdown",

--- a/practice/numpy-100/100_Numpy_exercises.ipynb
+++ b/practice/numpy-100/100_Numpy_exercises.ipynb
@@ -1403,7 +1403,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -1434,10 +1434,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "outputs": [
+    {
+     "ename": "ValueError",
+     "evalue": "assignment destination is read-only",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-13-0cf36813c766>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0mtmp\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mnp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0marange\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;36m10\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[0mtmp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mflags\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mwriteable\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mFalse\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 3\u001b[0;31m \u001b[0mtmp\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m1\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;31mValueError\u001b[0m: assignment destination is read-only"
+     ]
+    }
+   ],
+   "source": [
+    "tmp = np.arange(10)\n",
+    "tmp.flags.writeable = False\n",
+    "tmp[0] = 1"
+   ]
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## 概要
* numpy100問題集の問42~43を解いてみる
* 配列同士の比較に関する[ページ](https://github.com/kouta0530/jupyter/wiki/%E8%BF%91%E4%BC%BC%E5%80%A4%E3%81%AE%E6%AF%94%E8%BC%83%E3%82%92%E8%A1%8C%E3%81%86)を作成する



## 要件
* allcloseを使って近似値内での配列同士の比較を行う  
* numpyで作成した配列をflags.writeableでRead Onlyにする
