### PR TITLE
feat(scikit-learn): scikit-learnでデータを読み込んでみたり、SVMで学習させてみたり

### DIFF
--- a/practice/scikit-learn/Untitled.ipynb
+++ b/practice/scikit-learn/Untitled.ipynb
@@ -202,6 +202,43 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[1 0 0]\n",
+      " [1 0 0]\n",
+      " [0 1 0]\n",
+      " [0 1 0]\n",
+      " [0 0 1]]\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "array([[1, 0, 0],\n",
+       "       [1, 0, 0],\n",
+       "       [0, 1, 0],\n",
+       "       [0, 0, 0],\n",
+       "       [0, 0, 0]])"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "y = LabelBinarizer().fit_transform(y)\n",
+    "print(y)\n",
+    "classif.fit(X,y).predict(X)"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],

--- a/practice/scikit-learn/Untitled.ipynb
+++ b/practice/scikit-learn/Untitled.ipynb
@@ -106,6 +106,43 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(10, 2000)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "(10, 1973)"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "from sklearn import random_projection\n",
+    "\n",
+    "rng = np.random.RandomState(0)\n",
+    "X = rng.rand(10,2000)\n",
+    "X = np.array(X,dtype='float32')\n",
+    "print(X.shape)\n",
+    "\n",
+    "transformer = random_projection.GaussianRandomProjection()\n",
+    "X_new = transformer.fit_transform(X)\n",
+    "X_new.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],

--- a/practice/scikit-learn/Untitled.ipynb
+++ b/practice/scikit-learn/Untitled.ipynb
@@ -1,0 +1,86 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn import datasets\n",
+    "iris = datasets.load_iris()\n",
+    "digits = datasets.load_digits()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[ 0.  0.  5. ...  0.  0.  0.]\n",
+      " [ 0.  0.  0. ... 10.  0.  0.]\n",
+      " [ 0.  0.  0. ... 16.  9.  0.]\n",
+      " ...\n",
+      " [ 0.  0.  1. ...  6.  0.  0.]\n",
+      " [ 0.  0.  2. ... 12.  0.  0.]\n",
+      " [ 0.  0. 10. ... 12.  1.  0.]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(digits.data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([0, 1, 2, ..., 8, 9, 8])"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "digits.target"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/practice/scikit-learn/Untitled.ipynb
+++ b/practice/scikit-learn/Untitled.ipynb
@@ -143,6 +143,37 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([0, 0, 0, 0, 0])"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "from sklearn.datasets import load_iris\n",
+    "from sklearn.svm import SVC\n",
+    "\n",
+    "X,y = load_iris(return_X_y = True)\n",
+    "\n",
+    "clf = SVC()\n",
+    "clf.set_params(kernel='linear').fit(X,y)\n",
+    "clf.predict(X[:5])\n",
+    "\n",
+    "clf.set_params(kernel='rbf').fit(X,y)\n",
+    "clf.predict(X[:5])"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],

--- a/practice/scikit-learn/Untitled.ipynb
+++ b/practice/scikit-learn/Untitled.ipynb
@@ -174,6 +174,34 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([0, 0, 1, 1, 2])"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from sklearn.svm import SVC\n",
+    "from sklearn.multiclass import OneVsRestClassifier\n",
+    "from sklearn.preprocessing import LabelBinarizer\n",
+    "\n",
+    "X = [[1, 2], [2, 4], [4, 5], [3, 2], [3, 1]]\n",
+    "y = [0, 0, 1, 1, 2]\n",
+    "\n",
+    "classif = OneVsRestClassifier(estimator=SVC(random_state=0))\n",
+    "classif.fit(X,y).predict(X)"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],

--- a/practice/scikit-learn/Untitled.ipynb
+++ b/practice/scikit-learn/Untitled.ipynb
@@ -56,6 +56,56 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn import svm \n",
+    "clf = svm.SVC(gamma=0.001,C=100.)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "SVC(C=100.0, gamma=0.001)"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "clf.fit(digits.data[:-1],digits.target[:-1])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([8])"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "clf.predict(digits.data[-1:])"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],

--- a/practice/scikit-learn/tutorial.ipynb
+++ b/practice/scikit-learn/tutorial.ipynb
@@ -239,6 +239,34 @@
   },
   {
    "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[1, 1, 0, 0, 0],\n",
+       "       [1, 0, 1, 0, 0],\n",
+       "       [0, 1, 0, 1, 0],\n",
+       "       [1, 0, 1, 0, 0],\n",
+       "       [1, 0, 1, 0, 0]])"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from sklearn.preprocessing import MultiLabelBinarizer\n",
+    "\n",
+    "y = [[0, 1], [0, 2], [1, 3], [0, 2, 3], [2, 4]]\n",
+    "y = MultiLabelBinarizer().fit_transform(y)\n",
+    "classif.fit(X, y).predict(X)"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],

--- a/practice/scikit-learn/tutorial.ipynb
+++ b/practice/scikit-learn/tutorial.ipynb
@@ -7,6 +7,23 @@
    "outputs": [],
    "source": [
     "from sklearn import datasets\n",
+    "\n",
+    "\"\"\"\n",
+    "irisデータセットの内容\n",
+    "data:特徴量\n",
+    "feature_names：各カラムの特徴名が格納されている\n",
+    "target:分類に使うラベル\n",
+    "target_names: ラベル名一覧\n",
+    "\n",
+    "digitsデータセット\n",
+    "数字の画像データと対応するラベルのデータセット\n",
+    "\n",
+    "data:特徴量\n",
+    "target: 画像に対応する種類\n",
+    "\n",
+    "\"\"\"\n",
+    "\n",
+    "\n",
     "iris = datasets.load_iris()\n",
     "digits = datasets.load_digits()"
    ]
@@ -51,12 +68,12 @@
     }
    ],
    "source": [
-    "digits.target"
+    "digits.target #ラベル"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -66,7 +83,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -75,12 +92,14 @@
        "SVC(C=100.0, gamma=0.001)"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
+    "#　訓練データ一式、訓練データのラベル一式\n",
+    "#　画像が数字のなにか予測するモデルを学習\n",
     "clf.fit(digits.data[:-1],digits.target[:-1])"
    ]
   },
@@ -89,6 +108,17 @@
    "execution_count": 8,
    "metadata": {},
    "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[ 0.  0. 10. 14.  8.  1.  0.  0.  0.  2. 16. 14.  6.  1.  0.  0.  0.  0.\n",
+      "  15. 15.  8. 15.  0.  0.  0.  0.  5. 16. 16. 10.  0.  0.  0.  0. 12. 15.\n",
+      "  15. 12.  0.  0.  0.  4. 16.  6.  4. 16.  6.  0.  0.  8. 16. 10.  8. 16.\n",
+      "   8.  0.  0.  1.  8. 12. 14. 12.  1.  0.]]\n",
+      "[8]\n"
+     ]
+    },
     {
      "data": {
       "text/plain": [
@@ -101,7 +131,9 @@
     }
    ],
    "source": [
-    "clf.predict(digits.data[-1:])"
+    "print(digits.data[-1:])\n",
+    "print(digits.target[-1:])\n",
+    "clf.predict(digits.data[-1:]) #訓練データの末尾一つを入力して予測をする"
    ]
   },
   {
@@ -136,6 +168,7 @@
     "X = np.array(X,dtype='float32')\n",
     "print(X.shape)\n",
     "\n",
+    "## 任意の行列をランダムな行列と演算して、次元削減\n",
     "transformer = random_projection.GaussianRandomProjection()\n",
     "X_new = transformer.fit_transform(X)\n",
     "X_new.shape"


### PR DESCRIPTION
## 概要
* [An introduction to machine learning with scikit-learn](https://scikit-learn.org/stable/tutorial/basic/tutorial.html)を完了
* [scikit-learnでSVM](https://github.com/kouta0530/jupyter/wiki/Scikit-learn%E3%81%A7SVM)を作成

## 要件
* load_**でデータセット読み込む
* SVCモデルを生成する
* SVCモデルの誤差関数のパラメータをいじる
* 次元削減を行う
* 線形とrbfのアルゴリズムどちらを使用するか設定する
* 多クラス分類を行う
* 多クラスのラベルをone-hotに変換する